### PR TITLE
change sampe rate to bucket limit

### DIFF
--- a/middleware/traffic_enrich/bucket_limiter.go
+++ b/middleware/traffic_enrich/bucket_limiter.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+    "time"
+)
+// A simple rate limit algorithm.
+// Using a bucket to make sure every request can have at most x requests per hour.
+
+var requestHourlyCounts map[string]int = make(map[string]int)
+var theHour= -1
+
+func rateLimitAllowed(resource string, rateLimit int) bool {
+	hour := time.Now().Hour()
+	if theHour != hour {
+		theHour = hour
+		requestHourlyCounts = make(map[string]int)
+	}
+	count := requestHourlyCounts[resource]
+	if count > rateLimit {
+		return false
+	}
+	requestHourlyCounts[resource] = count + 1
+	return true
+}

--- a/middleware/traffic_enrich/settings.go
+++ b/middleware/traffic_enrich/settings.go
@@ -9,13 +9,13 @@ import (
 
 // Settings are a set of configurations loaded from environment variables.
 type Settings struct {
-	AwsRegion          string
-	AwsAccessKeyId     string
-	AwsSecretAccessKey string
-	S3BucketName       string
-	S3BucketPrefix     string
-	S3BatchLoadSize    int
-	TrafficSampleRate  float32
+	AwsRegion              string
+	AwsAccessKeyId         string
+	AwsSecretAccessKey     string
+	S3BucketName           string
+	S3BucketPrefix         string
+	S3BatchLoadSize        int
+	RequestHourlyRateLimit int
 }
 
 func lookupEnvOrDefault(key string, defaultValue string) string {
@@ -51,12 +51,12 @@ func newSettings() *Settings {
 	}
 	st.S3BatchLoadSize = batchLoadSize
 
-	trafficSampleRateStr := lookupEnvOrDefault("TRAFFIC_SAMPLE_RATE", "1.0")
-	trafficSampleRate, err := strconv.ParseFloat(trafficSampleRateStr, 32)
+	requestHourlyRateLimitStr := lookupEnvOrDefault("REQUEST_HOURLY_RATE_LIMIT", "100")
+	requestHourlyRateLimit, err := strconv.Atoi(requestHourlyRateLimitStr)
 	if err != nil {
-		logs.Fatal("Fail to convert", trafficSampleRateStr, "to float32.")
+		logs.Fatal("Fail to convert", requestHourlyRateLimitStr, "to integer.")
 	}
-	st.TrafficSampleRate = float32(trafficSampleRate)
+	st.RequestHourlyRateLimit = requestHourlyRateLimit
 
 	return st
 }


### PR DESCRIPTION
# Summary

Change the global request sample ratio to a bucket rate limit because the former is unfair. Some endpoints have far less traffic than others.