### PR TITLE
increase buffer

### DIFF
--- a/middleware/traffic_enrich/main.go
+++ b/middleware/traffic_enrich/main.go
@@ -24,7 +24,7 @@ func main() {
 	for {
 		buf := make([]byte, 0, 1024*1024)
 		scanner := bufio.NewScanner(os.Stdin)
-		scanner.Buffer(buf, 5*1024*1024) // initial 1MB, max 5MB.
+		scanner.Buffer(buf, 60*1024*1024) // initial 1MB, max 60MB.
 		logs.Info("Traffic enrichment starts.")
 		for scanner.Scan() {
 			encoded := scanner.Bytes()
@@ -55,6 +55,11 @@ func process(buf []byte, s3Loader *s3Loader) {
 
 	// Header contains space separated values of: request type, request id, and request start time (or round-trip time for responses)
 	meta := bytes.Split(header, []byte(" "))
+	if len(meta) != 3 {
+		logs.Error("Bad header", meta)
+		return
+	}
+
 	requestTimeNanoseconds, err := strconv.ParseInt(string(meta[2]), 10, 64)
 	if err != nil {
 		logs.Error("Fail to convert", string(meta[2]), "to int64")

--- a/middleware/traffic_enrich/main.go
+++ b/middleware/traffic_enrich/main.go
@@ -53,9 +53,14 @@ func process(buf []byte, s3Loader *s3Loader) {
 	headerSize := bytes.IndexByte(buf, '\n') + 1
 	header := buf[:headerSize-1]
 
-	// Header contains space separated values of: request type, request id, and request start time (or round-trip time for responses)
+	// Header contains four values separated by space:
+	// 1. request type
+	// 2. request id
+	// 3. request start time (or round-trip time for responses)
+	// 4. duration in nano seconds
+	// see https://github.com/dingxiong/goreplay/blob/d440b3dc8f2800b8147cd968f68aa10ec8b72e3b/input_raw.go#L101
 	meta := bytes.Split(header, []byte(" "))
-	if len(meta) != 3 {
+	if len(meta) != 4 {
 		logs.Error("Bad header", meta)
 		return
 	}


### PR DESCRIPTION
Goreplay crushed because it sees a large payload and it cannot handle it which leads to a bad content in the bytes buffer.

In contrast, our nginx sets request size limit to 60MB https://github.com/Greenbax/systems/blob/e25b18443709898f4853137a99f6b9ee5bfc7e65/server-ingress/helm/values.yaml#L30
```
Traffic enrichment stops. Something must be wrong:  bufio.Scanner: token too long
Traffic enrichment starts.
Traffic enrichment stops. Something must be wrong:  bufio.Scanner: token too long
Traffic enrichment starts.
panic: runtime error: index out of range [2] with length 1

goroutine 1 [running]:
main.process({0xc007278000, 0xd2e65, 0xc0007dfec0}, 0xc00700c000)
        /go/src/github.com/buger/goreplay/middleware/traffic_enrich/main.go:58 +0x86a
main.main()
        /go/src/github.com/buger/goreplay/middleware/traffic_enrich/main.go:35 +0x276
[DEBUG][elapsed 2h26m35.131725699s]: [MIDDLEWARE] command["/traffic_enrich"] error: "exit status 2"
```